### PR TITLE
Retry failed updates to address Issue #8

### DIFF
--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -284,6 +284,7 @@ function updatePhoto(photo, latitude, longitude)
         {
             // Get the current host URL
             var hostUrl = window.location.origin;
+            // Handle proxied hosted PhotoPrism if required.
             var UrlPath = window.location.pathname.match("(\/.*)\/library");
             if (UrlPath != null)
             {

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -54,16 +54,42 @@ top.window.addEventListener("message", function(message) {
     setTimeout(function(){
         // This is necessary because Vue.js responds by default to the input event rather than change event
         var event = new Event('input');
-        var leftBox = document.getElementsByClassName('input-latitude')[0];
-        leftBox.firstChild.firstChild.firstChild.childNodes[1].value = message.data.coordinates.lat;
-        leftBox.firstChild.firstChild.firstChild.childNodes[1].dispatchEvent(event);
-        var rightBox = document.getElementsByClassName('input-longitude')[0];
-        rightBox.firstChild.firstChild.firstChild.childNodes[1].value = message.data.coordinates.lon;
-        rightBox.firstChild.firstChild.firstChild.childNodes[1].dispatchEvent(event);
-    }, 10);
+        // Validate that the coordinates and it's children are available, then set the values for latitude and longitude.
+        if (message.data.coordinates !== undefined)
+            {
+                if (message.data.coordinates.lat !== undefined)
+                {
+                    var leftBox = document.getElementsByClassName('input-latitude')[0];
+                    if (leftBox !== undefined)
+                    {
+                        leftBox.firstChild.firstChild.firstChild.childNodes[1].value = message.data.coordinates.lat;
+                        leftBox.firstChild.firstChild.firstChild.childNodes[1].dispatchEvent(event);
+                    }
+                }
+                if (message.data.coordinates.lon !== undefined)
+                {
+                    var rightBox = document.getElementsByClassName('input-longitude')[0];
+                    if (rightBox !== undefined)
+                    {
+                        rightBox.firstChild.firstChild.firstChild.childNodes[1].value = message.data.coordinates.lon;
+                        rightBox.firstChild.firstChild.firstChild.childNodes[1].dispatchEvent(event);
+                    }
+                }
+            }
+        }, 10);
     // Save the coordinates to local storage in case it is a bulk update (to be used when the user triggers the bulk update)
-    localStorage.setItem('latitude', message.data.coordinates.lat)
-    localStorage.setItem('longitude', message.data.coordinates.lon)
+    // Make sure that the latitude and longitude are available
+    if (message.data.coordinates !== undefined)
+    {
+        if (message.data.coordinates.lat !== undefined)
+        {
+            localStorage.setItem('latitude', message.data.coordinates.lat);
+        }
+        if (message.data.coordinates.lon !== undefined)
+        {
+            localStorage.setItem('longitude', message.data.coordinates.lon);
+        }
+    }
 });
 
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,7 +12,7 @@
     },
     "content_scripts": [
         {
-          "matches": ["*://*/browse*", "*://*/library*"],
+          "matches": ["*://*/library/browse", "*://*/*/library/browse"],
           "css": ["extension.css"],
           "js": ["contentScript.js"]
         }


### PR DESCRIPTION
This pull adds the capability to retry updates that have failed in PhotoPrism due to either the existing known bug, or the future http 500 response.

This addresses the issue #8.
It also has the fix for proxy hosted instances of PhotoPrism.